### PR TITLE
Feature/aos 3109 stotte for manifest skjema v2 og v1 uthenting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,11 @@ The service is currently under development
 
 The component is named after Cantus the Minstrel from the TV-show Fraggle Rock (http://muppet.wikia.com/wiki/Cantus_the_Minstrel).
 
+To be able to run and make calls to Cantus you have to define variables in the file .spring-boot-devtools.properties located in the home folder.
+
+The variables nedded are :
+- cantus.docker-registry-url = localhost
+- cantus.docker-registry-url-allowed = localhost, test
+
+
 More information will come!

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = "1.3.10"
+  ext.kotlin_version = "1.3.11"
   ext.repos = {
     jcenter()
     mavenLocal()
@@ -18,7 +18,7 @@ buildscript {
 }
 
 plugins {
-  id 'org.jetbrains.kotlin.plugin.spring' version '1.3.10'
+  id 'org.jetbrains.kotlin.plugin.spring' version '1.3.11'
   id 'org.springframework.boot' version '2.1.1.RELEASE'
   id 'org.jlleitschuh.gradle.ktlint' version '6.2.0'
   id 'com.github.ben-manes.versions' version '0.20.0'
@@ -52,12 +52,12 @@ def junitJupiterVersion = dependencyManagement.importedProperties['junit-jupiter
 dependencies {
   compile(
       "com.fasterxml.jackson.module:jackson-module-kotlin",
-      "no.skatteetaten.aurora.springboot:aurora-spring-boot2-starter:1.3.1",
+      "no.skatteetaten.aurora.springboot:aurora-spring-boot2-starter:1.4.1",
       "org.springframework.boot:spring-boot-starter-web",
       "org.springframework.boot:spring-boot-starter-security",
       "org.springframework.boot:spring-boot-starter-actuator",
       "org.springframework.boot:spring-boot-starter-webflux",
-
+      'org.springframework.boot:spring-boot-starter-hateoas',
       "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 
   )

--- a/src/main/kotlin/no/skatteetaten/aurora/cantus/ApplicationConfig.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/cantus/ApplicationConfig.kt
@@ -69,6 +69,7 @@ class ApplicationConfig {
                         MediaType.valueOf("application/vnd.docker.distribution.manifest.v1+json"),
                         MediaType.valueOf("application/vnd.docker.distribution.manifest.v1+prettyjws"),
                         MediaType.valueOf("application/vnd.docker.distribution.manifest.v2+json"),
+                        MediaType.valueOf("application/vnd.docker.container.image.v1+json"),
                         MediaType.valueOf("application/json")
                     )
                 )

--- a/src/main/kotlin/no/skatteetaten/aurora/cantus/ApplicationConfig.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/cantus/ApplicationConfig.kt
@@ -41,9 +41,8 @@ class ApplicationConfig {
     @Bean
     fun webClient() = webClientBuilder().build()
 
-    fun webClientBuilder(): WebClient.Builder {
-
-        return WebClient
+    fun webClientBuilder(): WebClient.Builder =
+        WebClient
             .builder()
             .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .exchangeStrategies(exchangeStrategies())
@@ -56,10 +55,10 @@ class ApplicationConfig {
                 it.toMono()
             })
             .clientConnector(clientConnector())
-    }
 
     private fun exchangeStrategies(): ExchangeStrategies {
         val objectMapper = createObjectMapper()
+
         return ExchangeStrategies
             .builder()
             .codecs {

--- a/src/main/kotlin/no/skatteetaten/aurora/cantus/ApplicationConfig.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/cantus/ApplicationConfig.kt
@@ -1,11 +1,103 @@
 package no.skatteetaten.aurora.cantus
 
-import org.springframework.boot.web.client.RestTemplateBuilder
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.netty.channel.ChannelOption
+import io.netty.handler.ssl.SslContextBuilder
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory
+import io.netty.handler.timeout.ReadTimeoutHandler
+import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
+import org.springframework.http.codec.json.Jackson2JsonDecoder
+import org.springframework.http.codec.json.Jackson2JsonEncoder
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction
+import org.springframework.web.reactive.function.client.ExchangeStrategies
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.toMono
+import reactor.netty.http.client.HttpClient
+import reactor.netty.tcp.SslProvider
+import reactor.netty.tcp.TcpClient
+import java.util.concurrent.TimeUnit
+import kotlin.math.min
 
 @Configuration
 class ApplicationConfig {
+
+    private val logger = LoggerFactory.getLogger(ApplicationConfig::class.java)
+
     @Bean
-    fun restTemplate(restTemplateBuilder: RestTemplateBuilder) = restTemplateBuilder.build()
+    fun mappingJackson2HttpMessageConverter(): MappingJackson2HttpMessageConverter {
+        val jsonConverter = MappingJackson2HttpMessageConverter()
+        val objectMapper = jacksonObjectMapper()
+
+        jsonConverter.objectMapper = objectMapper
+        return jsonConverter
+    }
+
+    @Bean
+    fun webClient() = webClientBuilder().build()
+
+    fun webClientBuilder(): WebClient.Builder {
+
+        return WebClient
+            .builder()
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .exchangeStrategies(exchangeStrategies())
+            .filter(ExchangeFilterFunction.ofRequestProcessor {
+                val bearer = it.headers()[HttpHeaders.AUTHORIZATION]?.firstOrNull()?.let { token ->
+                    val t = token.substring(0, min(token.length, 11)).replace("Bearer", "")
+                    "bearer=$t"
+                } ?: ""
+                logger.debug("HttpRequest method=${it.method()} url=${it.url()} $bearer")
+                it.toMono()
+            })
+            .clientConnector(clientConnector())
+    }
+
+    private fun exchangeStrategies(): ExchangeStrategies {
+        val objectMapper = createObjectMapper()
+        return ExchangeStrategies
+            .builder()
+            .codecs {
+                it.defaultCodecs().jackson2JsonDecoder(
+                    Jackson2JsonDecoder(
+                        objectMapper,
+                        MediaType.valueOf("application/vnd.docker.distribution.manifest.v1+json"),
+                        MediaType.valueOf("application/vnd.docker.distribution.manifest.v1+prettyjws"),
+                        MediaType.valueOf("application/vnd.docker.distribution.manifest.v2+json"),
+                        MediaType.valueOf("application/json")
+                    )
+                )
+                it.defaultCodecs().jackson2JsonEncoder(
+                    Jackson2JsonEncoder(
+                        objectMapper,
+                        MediaType.valueOf("application/json")
+                    )
+                )
+            }
+            .build()
+    }
+
+    private fun clientConnector(): ReactorClientHttpConnector {
+
+        val sslProvider = SslProvider.builder().sslContext(
+            SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE)
+        ).defaultConfiguration(SslProvider.DefaultConfigurationType.NONE).build()
+
+        val tcpClient = TcpClient.create()
+            .secure(sslProvider)
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 30000)
+            .doOnConnected { connection ->
+                connection.addHandlerLast(ReadTimeoutHandler(30000.toLong(), TimeUnit.MILLISECONDS))
+            }
+
+        val httpClient = HttpClient.from(tcpClient)
+        httpClient.compress(true)
+
+        return ReactorClientHttpConnector(httpClient)
+    }
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/cantus/Main.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/cantus/Main.kt
@@ -7,6 +7,5 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 class Main
 
 fun main(args: Array<String>) {
-
     SpringApplication.run(Main::class.java, *args)
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryController.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryController.kt
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-class DockerRegistryController(val dockerRegistryService: DockerRegistryService<Any?>) {
+class DockerRegistryController(val dockerRegistryService: DockerRegistryService) {
 
     @GetMapping("/{affiliation}/{name}/{tag}/manifest")
     fun getManifestInformation(

--- a/src/main/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryController.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryController.kt
@@ -14,21 +14,18 @@ class DockerRegistryController(val dockerRegistryService: DockerRegistryService<
         @PathVariable affiliation: String,
         @PathVariable name: String,
         @PathVariable tag: String,
-        @RequestParam(required = false) dockerRegistryUrl: String?
-    ): Map<String, String> {
-        return dockerRegistryService
-            .getImageManifestInformation(affiliation, name, tag, dockerRegistryUrl)
-            .ifEmpty { throw NoSuchResourceException("Could not find manifest for image $affiliation/$name") }
-    }
+        @RequestParam(required = false) dockerRegistryUrl: String?) =
+            dockerRegistryService
+                .getImageManifestInformation(affiliation, name, tag, dockerRegistryUrl)
 
-    @GetMapping("/{affiliation}/{name}/tags")
+
+        @GetMapping("/{affiliation}/{name}/tags")
     fun getImageTags(
         @PathVariable affiliation: String,
         @PathVariable name: String,
         @RequestParam(required = false) dockerRegistryUrl: String?
     ) =
-        dockerRegistryService.getImageTags("$affiliation/$name", dockerRegistryUrl)
-            .ifEmpty { throw NoSuchResourceException("Could not find tags for image $affiliation/$name") }
+        dockerRegistryService.getImageTags(affiliation, name, dockerRegistryUrl)
 
     @GetMapping("/{affiliation}/{name}/tags/semantic")
     fun getImageTagsSemantic(
@@ -36,6 +33,5 @@ class DockerRegistryController(val dockerRegistryService: DockerRegistryService<
         @PathVariable name: String,
         @RequestParam(required = false) dockerRegistryUrl: String?
     ) =
-        dockerRegistryService.getImageTagsGroupedBySemanticVersion("$affiliation/$name", dockerRegistryUrl)
-            .ifEmpty { throw NoSuchResourceException("Not possible to group tags by semantic version. Could not find tags for image $affiliation/$name") }
+        dockerRegistryService.getImageTagsGroupedBySemanticVersion(affiliation, name, dockerRegistryUrl)
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryController.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryController.kt
@@ -17,7 +17,7 @@ class DockerRegistryController(val dockerRegistryService: DockerRegistryService)
         @RequestParam(required = false) dockerRegistryUrl: String?
     ): Map<String, String> {
         return dockerRegistryService
-            .getImageManifestInformation("$affiliation/$name", tag, dockerRegistryUrl)
+            .getImageManifestInformation(affiliation, name, tag, dockerRegistryUrl)
             .ifEmpty { throw NoSuchResourceException("Could not find manifest for image $affiliation/$name") }
     }
 

--- a/src/main/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryController.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryController.kt
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-class DockerRegistryController(val dockerRegistryService: DockerRegistryService) {
+class DockerRegistryController(val dockerRegistryService: DockerRegistryService<Any?>) {
 
     @GetMapping("/{affiliation}/{name}/{tag}/manifest")
     fun getManifestInformation(

--- a/src/main/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryController.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryController.kt
@@ -14,12 +14,12 @@ class DockerRegistryController(val dockerRegistryService: DockerRegistryService<
         @PathVariable affiliation: String,
         @PathVariable name: String,
         @PathVariable tag: String,
-        @RequestParam(required = false) dockerRegistryUrl: String?) =
-            dockerRegistryService
-                .getImageManifestInformation(affiliation, name, tag, dockerRegistryUrl)
+        @RequestParam(required = false) dockerRegistryUrl: String?
+    ) =
+        dockerRegistryService
+            .getImageManifestInformation(affiliation, name, tag, dockerRegistryUrl)
 
-
-        @GetMapping("/{affiliation}/{name}/tags")
+    @GetMapping("/{affiliation}/{name}/tags")
     fun getImageTags(
         @PathVariable affiliation: String,
         @PathVariable name: String,

--- a/src/main/kotlin/no/skatteetaten/aurora/cantus/controller/ErrorHandler.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/cantus/controller/ErrorHandler.kt
@@ -7,7 +7,11 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.context.request.WebRequest
+import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
+import reactor.core.publisher.Mono
+import reactor.core.publisher.toMono
+import java.time.Duration
 
 @ControllerAdvice
 class ErrorHandler : ResponseEntityExceptionHandler() {
@@ -35,3 +39,23 @@ class ErrorHandler : ResponseEntityExceptionHandler() {
         return handleExceptionInternal(e, response, headers, httpStatus, request)
     }
 }
+
+fun <T> Mono<T>.blockNonNullAndHandleError(duration: Duration = Duration.ofSeconds(30), sourceSystem: String? = null) =
+    this.switchIfEmpty(SourceSystemException("Empty response", sourceSystem = sourceSystem).toMono())
+        .blockAndHandleError(duration, sourceSystem)!!
+
+fun <T> Mono<T>.blockAndHandleError(duration: Duration = Duration.ofSeconds(30), sourceSystem: String? = null) =
+    this.handleError(sourceSystem).toMono().block(duration)
+
+private fun <T> Mono<T>.handleError(sourceSystem: String?) =
+    this.doOnError {
+        if (it is WebClientResponseException) {
+            throw SourceSystemException(
+                message = "Error in response, status:${it.statusCode} message:${it.statusText}",
+                cause = it,
+                sourceSystem = sourceSystem,
+                code = it.statusCode.name
+            )
+        }
+        throw SourceSystemException("Error response", it)
+    }

--- a/src/main/kotlin/no/skatteetaten/aurora/cantus/controller/ErrorHandler.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/cantus/controller/ErrorHandler.kt
@@ -49,6 +49,7 @@ fun <T> Mono<T>.blockAndHandleError(duration: Duration = Duration.ofSeconds(30),
 
 private fun <T> Mono<T>.handleError(sourceSystem: String?) =
     this.doOnError {
+
         if (it is WebClientResponseException) {
             throw SourceSystemException(
                 message = "Error in response, status:${it.statusCode} message:${it.statusText}",
@@ -57,5 +58,6 @@ private fun <T> Mono<T>.handleError(sourceSystem: String?) =
                 code = it.statusCode.name
             )
         }
-        throw SourceSystemException("Error response", it)
+
+        throw SourceSystemException("Error response ${it.message}", it)
     }

--- a/src/main/kotlin/no/skatteetaten/aurora/cantus/controller/ErrorHandler.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/cantus/controller/ErrorHandler.kt
@@ -21,11 +21,6 @@ class ErrorHandler : ResponseEntityExceptionHandler() {
         return handleException(e, request, HttpStatus.INTERNAL_SERVER_ERROR)
     }
 
-    @ExceptionHandler(NoSuchResourceException::class)
-    fun handleResourceNotFound(e: NoSuchResourceException, request: WebRequest): ResponseEntity<Any>? {
-        return handleException(e, request, HttpStatus.NOT_FOUND)
-    }
-
     @ExceptionHandler(BadRequestException::class)
     fun handleBadRequest(e: BadRequestException, request: WebRequest): ResponseEntity<Any>? {
         return handleException(e, request, HttpStatus.BAD_REQUEST)

--- a/src/main/kotlin/no/skatteetaten/aurora/cantus/controller/Exceptions.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/cantus/controller/Exceptions.kt
@@ -1,19 +1,16 @@
 package no.skatteetaten.aurora.cantus.controller
 
-class NoSuchResourceException(message: String) : RuntimeException(message)
-class DockerRegistryException(message: String) : RuntimeException(message)
 class BadRequestException(message: String) : RuntimeException(message)
+
 open class CantusException(
     message: String,
     cause: Throwable? = null,
-    val code: String = "",
-    val errorMessage: String = message
+    val code: String = ""
 ) : java.lang.RuntimeException(message, cause)
 
 class SourceSystemException(
     message: String,
     cause: Throwable? = null,
     code: String = "",
-    errorMessage: String = message,
     val sourceSystem: String? = null
-) : CantusException(message, cause, code, errorMessage)
+) : CantusException(message, cause, code)

--- a/src/main/kotlin/no/skatteetaten/aurora/cantus/controller/Exceptions.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/cantus/controller/Exceptions.kt
@@ -3,10 +3,12 @@ package no.skatteetaten.aurora.cantus.controller
 class NoSuchResourceException(message: String) : RuntimeException(message)
 class DockerRegistryException(message: String) : RuntimeException(message)
 class BadRequestException(message: String) : RuntimeException(message)
-open class CantusException(message: String,
+open class CantusException(
+    message: String,
     cause: Throwable? = null,
     val code: String = "",
-    val errorMessage: String = message): java.lang.RuntimeException(message, cause)
+    val errorMessage: String = message
+) : java.lang.RuntimeException(message, cause)
 
 class SourceSystemException(
     message: String,

--- a/src/main/kotlin/no/skatteetaten/aurora/cantus/controller/Exceptions.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/cantus/controller/Exceptions.kt
@@ -3,3 +3,15 @@ package no.skatteetaten.aurora.cantus.controller
 class NoSuchResourceException(message: String) : RuntimeException(message)
 class DockerRegistryException(message: String) : RuntimeException(message)
 class BadRequestException(message: String) : RuntimeException(message)
+open class CantusException(message: String,
+    cause: Throwable? = null,
+    val code: String = "",
+    val errorMessage: String = message): java.lang.RuntimeException(message, cause)
+
+class SourceSystemException(
+    message: String,
+    cause: Throwable? = null,
+    code: String = "",
+    errorMessage: String = message,
+    val sourceSystem: String? = null
+) : CantusException(message, cause, code, errorMessage)

--- a/src/main/kotlin/no/skatteetaten/aurora/cantus/objectMapperConfigurer.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/cantus/objectMapperConfigurer.kt
@@ -1,0 +1,18 @@
+package no.skatteetaten.aurora.cantus
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.springframework.hateoas.hal.Jackson2HalModule
+
+fun createObjectMapper() =
+    jacksonObjectMapper().apply {
+        configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+        configure(SerializationFeature.INDENT_OUTPUT, true)
+        registerModules(JavaTimeModule(), Jackson2HalModule())
+        registerKotlinModule()
+        enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+        disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+    }

--- a/src/main/kotlin/no/skatteetaten/aurora/cantus/service/DockerRegistryService.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/cantus/service/DockerRegistryService.kt
@@ -124,7 +124,7 @@ class DockerRegistryService(
             dockerVersionLabel to dockerVersion,
             dockerContentDigestLabel to dockerContentDigest,
             createdLabel to created
-        ).mapKeys { it.key.toUpperCase() }
+        ).mapKeys { it.key.toUpperCase().replace("-", "_") }
 
         return imageManifestEnvInformation + imageManifestConfigInformation
     }

--- a/src/main/kotlin/no/skatteetaten/aurora/cantus/service/DockerRegistryService.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/cantus/service/DockerRegistryService.kt
@@ -4,15 +4,21 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import no.skatteetaten.aurora.cantus.controller.BadRequestException
 import no.skatteetaten.aurora.cantus.controller.DockerRegistryException
+import no.skatteetaten.aurora.cantus.controller.SourceSystemException
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.BodyExtractor
+import org.springframework.web.reactive.function.BodyExtractors
 import org.springframework.web.reactive.function.client.ClientResponse
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.reactive.function.client.bodyToMono
 import reactor.core.publisher.Mono
+import reactor.core.publisher.toMono
+import java.time.Duration
 import java.util.HashSet
 import java.util.function.Function
 import java.util.function.Predicate
@@ -27,10 +33,10 @@ class DockerRegistryService(
     @Value("\${cantus.docker-registry-url}") val dockerRegistryUrl: String,
     @Value("\${cantus.docker-registry-url-allowed}") val dockerRegistryUrlsAllowed: List<String>
 ) {
-    val DOCKER_MANIFEST_ACCEPT: List<MediaType> = listOf(
+    val dockerManfestAccept: List<MediaType> = listOf(
         MediaType.valueOf("application/vnd.docker.distribution.manifest.v2+json"),
-        MediaType.valueOf("application/vnd.docker.distribution.manifest.v1+json"),
-        MediaType.valueOf("application/json")
+        MediaType.valueOf("application/vnd.docker.distribution.manifest.v1+json")
+        //MediaType.valueOf("application/json")
     )
 
     val manifestEnvLabels: HashSet<String> = hashSetOf(
@@ -60,9 +66,9 @@ class DockerRegistryService(
         logger.debug("Retrieving manifest from $url")
         logger.debug("Trying to get image with name $imageName and tag $imageTag")
         val manifestUri = createManifestRequest(url, imageName, imageTag)
-        val dockerResponse = getManifestFromRegistry(manifestUri)
-        val dockerContentDigest = dockerResponse.second ?: throw DockerRegistryException("Error from Docker Registry")
-        val manifestBody = dockerResponse.first?.block() ?: throw DockerRegistryException("Error from Docker Registry")
+        val dockerResponse = getManifestFromRegistry(imageName, manifestUri)
+        val dockerContentDigest = dockerResponse?.second ?: throw DockerRegistryException("Error from Docker Registry")
+        val manifestBody = dockerResponse.first
 
         return extractManifestInformation(manifestBody, dockerContentDigest)
     }
@@ -100,17 +106,14 @@ class DockerRegistryService(
         manifestBody: JsonNode,
         dockerContentDigest: String
     ): Map<String, String> {
-
-        val v1Compatibility = manifestBody.getV1CompatibilityFromManifest()
-
-        val environmentVariables = v1Compatibility.getEnvironmentVariablesFromManifest()
+        val environmentVariables = manifestBody.getEnvironmentVariablesFromManifest()
 
         val imageManifestEnvInformation = environmentVariables
             .filter { manifestEnvLabels.contains(it.key) }
             .mapKeys { it.key.toUpperCase() }
 
-        val dockerVersion = v1Compatibility.getVariableFromManifestBody(dockerVersionLabel)
-        val created = v1Compatibility.getVariableFromManifestBody(createdLabel)
+        val dockerVersion = manifestBody.getVariableFromManifestBody(dockerVersionLabel)
+        val created = manifestBody.getVariableFromManifestBody(createdLabel)
 
         val imageManifestConfigInformation = mapOf(
             dockerVersionLabel to dockerVersion,
@@ -125,49 +128,77 @@ class DockerRegistryService(
         if (!alllowedUrls.any { allowedUrl: String -> urlToValidate == allowedUrl }) throw BadRequestException("Invalid Docker Registry URL")
     }
 
-    private final inline fun <reified T : Any> getBodyFromDockerRegistry(
+    private final inline fun <reified T: Any> getBodyFromDockerRegistry(
         apiUrl: String
     ): T? = webClient
         .get()
         .uri(apiUrl)
-        .retrieve()
-        .onStatus(Predicate.isEqual<HttpStatus>(HttpStatus.NOT_FOUND), Function { Mono.empty() })
-        .bodyToMono<T>()
-        .block()
+        .exchange()
+        .flatMap {resp ->
+            resp.bodyToMono(T::class.java)
+        }
+        .blockAndHandleError(sourceSystem = "docker")
 
-    private fun ClientResponse.getBodyAsJson(): JsonNode? = this.bodyToMono(JsonNode::class.java).block()
 
     private fun getManifestFromRegistry(
+        imageName: String,
         apiUrl: String
-    ): Pair<Mono<JsonNode>?, String?> {
-        val clientResponse =
-            webClient
-                .get()
-                .uri(apiUrl)
-                .headers {
-                    it.accept = DOCKER_MANIFEST_ACCEPT
+    ): Pair<JsonNode, String>? {
+        return webClient
+            .get()
+            .uri(apiUrl)
+            .headers {
+                it.accept = dockerManfestAccept
+            }
+            .exchange()
+            .flatMap { resp ->
+                val contentType = resp.headers().contentType().get().toString()
+                val headers = resp.headers().header(dockerContentDigestLabel).first()
+
+                resp.bodyToMono<JsonNode>().map {
+                    it.checkCompatibility(contentType, imageName) to headers
                 }
-                .exchange()
-                .block()
-                ?.checkResponseStatusCode()
-                ?: throw DockerRegistryException("Error in response from docker registry")
 
-        val bodyOfManifest = clientResponse.bodyToMono<JsonNode>()
-        val headerOfManifest = clientResponse.headers().header(dockerContentDigestLabel)
-        return bodyOfManifest to headerOfManifest[0]
+            }.blockNonNullAndHandleError(sourceSystem = "docker")
     }
-}
 
-private fun ClientResponse.checkResponseStatusCode(): ClientResponse {
-    when (this.statusCode()) {
-        HttpStatus.NOT_FOUND -> throw DockerRegistryException("Image information in docker registry not found")
-        HttpStatus.INTERNAL_SERVER_ERROR -> throw DockerRegistryException("Error from docker registry")
-        HttpStatus.BAD_REQUEST -> throw DockerRegistryException("Error in request sent to docker registry")
-        else -> {
-            return this
+    private fun JsonNode.checkCompatibility(
+        contentType: String,
+        imageName: String
+    ): JsonNode =
+        when (contentType) {
+            "application/vnd.docker.distribution.manifest.v2+json" ->
+                this.getV2Information(imageName)
+            else -> {
+                this.getV1CompatibilityFromManifest()
+            }
         }
+
+    private fun JsonNode.getV2Information(imageName: String): JsonNode {
+        val configDigest = this.at("/config").get("digest")
+        return getBodyFromDockerRegistry("/$imageName/blobs/$configDigest") ?: jacksonObjectMapper().createObjectNode()
     }
 }
+
+fun <T> Mono<T>.blockNonNullAndHandleError(duration: Duration = Duration.ofSeconds(30), sourceSystem: String? = null) =
+    this.switchIfEmpty(SourceSystemException("Empty response", sourceSystem = sourceSystem).toMono())
+        .blockAndHandleError(duration, sourceSystem)!!
+
+fun <T> Mono<T>.blockAndHandleError(duration: Duration = Duration.ofSeconds(30), sourceSystem: String? = null) =
+    this.handleError(sourceSystem).toMono().block(duration)
+
+private fun <T> Mono<T>.handleError(sourceSystem: String?) =
+    this.doOnError {
+        if (it is WebClientResponseException) {
+            throw SourceSystemException(
+                message = "Error in response, status:${it.statusCode} message:${it.statusText}",
+                cause = it,
+                sourceSystem = sourceSystem,
+                code = it.statusCode.name
+            )
+        }
+        throw SourceSystemException("Error response", it)
+    }
 
 private fun JsonNode.getV1CompatibilityFromManifest() =
     jacksonObjectMapper().readTree(this.get("history")?.get(0)?.get("v1Compatibility")?.asText() ?: "")

--- a/src/main/kotlin/no/skatteetaten/aurora/cantus/service/DockerRegistryService.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/cantus/service/DockerRegistryService.kt
@@ -70,11 +70,12 @@ class DockerRegistryService<T>(
                     it.accept = dockerManfestAccept
                 }
         }
-        
+
         val dockerContentDigest = dockerResponse.dockerContentDigest ?: return emptyMap()
         val contentType = dockerResponse.contentType ?: return emptyMap()
         val manifestBody =
-            dockerResponse.manifestBody?.checkSchemaCompatibility(contentType, imageAffiliation, imageName) ?: return emptyMap()
+            dockerResponse.manifestBody?.checkSchemaCompatibility(contentType, imageAffiliation, imageName)
+                ?: return emptyMap()
 
         return extractManifestInformation(manifestBody, dockerContentDigest)
     }
@@ -90,8 +91,6 @@ class DockerRegistryService<T>(
                 .get()
                 .uri("$url/v2/{imageGroup}/{imageName}/tags/list", imageGroup, imageName)
         }
-
-
 
         return tagsResponse?.tags ?: emptyList()
     }

--- a/src/main/kotlin/no/skatteetaten/aurora/cantus/service/DockerRegistryService.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/cantus/service/DockerRegistryService.kt
@@ -6,7 +6,6 @@ import no.skatteetaten.aurora.cantus.controller.BadRequestException
 import no.skatteetaten.aurora.cantus.controller.blockNonNullAndHandleError
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
@@ -161,25 +160,25 @@ class DockerRegistryService(
 
     private fun JsonNode.checkSchemaCompatibility(
         contentType: String,
-        imageAffiliation: String,
+        imageGroup: String,
         imageName: String
     ): JsonNode =
         when (contentType) {
             "application/vnd.docker.distribution.manifest.v2+json" ->
-                this.getV2Information(imageAffiliation, imageName)
+                this.getV2Information(imageGroup, imageName)
             else -> {
                 this.getV1CompatibilityFromManifest()
             }
         }
 
-    private fun JsonNode.getV2Information(imageAffiliation: String, imageName: String): JsonNode {
+    private fun JsonNode.getV2Information(imageGroup: String, imageName: String): JsonNode {
         val configDigest = this.at("/config").get("digest").asText().replace("\\s".toRegex(), "").split(":").last()
         return getBodyFromDockerRegistry { webClient ->
             webClient
                 .get()
                 .uri(
                     "$dockerRegistryUrl/v2/{imageGroup}/{imageName}/blobs/sha256:{configDigest}",
-                    imageAffiliation,
+                    imageGroup,
                     imageName,
                     configDigest
                 )

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,7 +15,7 @@ aurora:
 
 logging:
   level:
-    no.skatteetaten.aurora.cantus: INFO
+    no.skatteetaten.aurora.cantus: DEBUG
     org:
       hibernate: WARN
       springframework: WARN
@@ -37,7 +37,7 @@ server:
 
 management:
     server:
-        port: 8091
+        port: 8095
 
 logging:
     pattern:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -32,6 +32,13 @@ cantus:
     username: cantus
     password: cantus
 
+server:
+    port: 8090
+
+management:
+    server:
+        port: 8091
+
 logging:
     pattern:
       console: "%d [%-9.9thread] %highlight(%-5level) %cyan(%logger:%L) %X - %msg %n%rEx{full}"

--- a/src/test/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryControllerTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryControllerTest.kt
@@ -56,8 +56,10 @@ class DockerRegistryControllerTest {
         ]
     )
     fun `Get docker registry image info given missing resource return empty list or map`(path: String) {
-        print(mockMvc.perform(get(path))
-            .andExpect ( status().isOk )
-            .andExpect(jsonPath("$.[*]").isEmpty))
+        print(
+            mockMvc.perform(get(path))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.[*]").isEmpty)
+        )
     }
 }

--- a/src/test/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryControllerTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryControllerTest.kt
@@ -3,6 +3,7 @@ package no.skatteetaten.aurora.cantus.controller
 import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.anyOrNull
 import no.skatteetaten.aurora.cantus.service.DockerRegistryService
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.BDDMockito.given
@@ -31,10 +32,11 @@ class DockerRegistryControllerTest {
         ]
     )
     fun `Get docker registry image info`(path: String) {
-        given(dockerService.getImageManifestInformation(any(), any(), anyOrNull())).willReturn(mapOf("1" to "2"))
-        given(dockerService.getImageTags(any(), anyOrNull())).willReturn(listOf("1", "2"))
+        given(dockerService.getImageManifestInformation(any(), any(), any(), anyOrNull())).willReturn(mapOf("1" to "2"))
+        given(dockerService.getImageTags(any(), any(), anyOrNull())).willReturn(listOf("1", "2"))
         given(
             dockerService.getImageTagsGroupedBySemanticVersion(
+                any(),
                 any(),
                 anyOrNull()
             )
@@ -44,6 +46,7 @@ class DockerRegistryControllerTest {
             .andExpect(jsonPath("$").isNotEmpty)
     }
 
+    @Disabled
     @ParameterizedTest
     @ValueSource(
         strings = [
@@ -52,8 +55,9 @@ class DockerRegistryControllerTest {
             "/no_skatteetaten_aurora_demo/whoami/tags/semantic"
         ]
     )
-    fun `Get docker registry image info given missing resource return 404`(path: String) {
-        mockMvc.perform(get(path))
-            .andExpect(status().isNotFound)
+    fun `Get docker registry image info given missing resource return empty list or map`(path: String) {
+        print(mockMvc.perform(get(path))
+            .andExpect ( status().isOk )
+            .andExpect(jsonPath("$.[*]").isEmpty))
     }
 }

--- a/src/test/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryControllerTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryControllerTest.kt
@@ -59,7 +59,7 @@ class DockerRegistryControllerTest {
         print(
             mockMvc.perform(get(path))
                 .andExpect(status().isOk)
-                .andExpect(jsonPath("$.[*]").isEmpty)
+                .andExpect(jsonPath("$").isEmpty)
         )
     }
 }

--- a/src/test/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryControllerTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryControllerTest.kt
@@ -18,7 +18,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 @WebMvcTest(value = [DockerRegistryController::class, ErrorHandler::class], secure = false)
 class DockerRegistryControllerTest {
     @MockBean
-    private lateinit var dockerService: DockerRegistryService<Any?>
+    private lateinit var dockerService: DockerRegistryService
 
     @Autowired
     private lateinit var mockMvc: MockMvc

--- a/src/test/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryControllerTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryControllerTest.kt
@@ -17,7 +17,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 @WebMvcTest(value = [DockerRegistryController::class, ErrorHandler::class], secure = false)
 class DockerRegistryControllerTest {
     @MockBean
-    private lateinit var dockerService: DockerRegistryService
+    private lateinit var dockerService: DockerRegistryService<Any?>
 
     @Autowired
     private lateinit var mockMvc: MockMvc

--- a/src/test/kotlin/no/skatteetaten/aurora/cantus/service/DockerRegistryServiceTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/cantus/service/DockerRegistryServiceTest.kt
@@ -26,7 +26,7 @@ class DockerRegistryServiceTest {
     private val server = MockWebServer()
     private val url = server.url("/")
     private val allowedUrls = listOf("docker-registry.no", "internal-docker-registry.no")
-    private val dockerService = DockerRegistryService(WebClient.create(), url.toString(), listOf(url.toString()))
+    private val dockerService = DockerRegistryService<Any>(WebClient.create(), url.toString(), listOf(url.toString()))
 
     @BeforeEach
     fun setUp() {
@@ -91,7 +91,7 @@ class DockerRegistryServiceTest {
 
     @Test
     fun `Verify that disallowed docker registry url returns bad request error`() {
-        val dockerServiceTestDisallowed = DockerRegistryService(WebClient.create(), url.toString(), allowedUrls)
+        val dockerServiceTestDisallowed = DockerRegistryService<Any>(WebClient.create(), url.toString(), allowedUrls)
 
         server.execute {
             val exception = catch { dockerServiceTestDisallowed.getImageManifestInformation(imageAffiliation, imageName, tagName) }

--- a/src/test/kotlin/no/skatteetaten/aurora/cantus/service/DockerRegistryServiceTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/cantus/service/DockerRegistryServiceTest.kt
@@ -41,7 +41,7 @@ class DockerRegistryServiceTest {
             val jsonResponse = dockerService.getImageManifestInformation(imageRepoName, tagName)
             assert(jsonResponse).isNotNull {
                 assert(it.actual.size).isEqualTo(10)
-                assert(it.actual["DOCKER-CONTENT-DIGEST"]).isEqualTo("SHA::256")
+                assert(it.actual["DOCKER_CONTENT_DIGEST"]).isEqualTo("SHA::256")
                 assert(it.actual["DOCKER_VERSION"]).isEqualTo("1.13.1")
                 assert(it.actual["CREATED"]).isEqualTo("2018-11-05T14:01:22.654389192Z")
             }

--- a/src/test/kotlin/no/skatteetaten/aurora/cantus/service/DockerRegistryServiceTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/cantus/service/DockerRegistryServiceTest.kt
@@ -94,7 +94,8 @@ class DockerRegistryServiceTest {
         val dockerServiceTestDisallowed = DockerRegistryService<Any>(WebClient.create(), url.toString(), allowedUrls)
 
         server.execute {
-            val exception = catch { dockerServiceTestDisallowed.getImageManifestInformation(imageGroup, imageName, tagName) }
+            val exception =
+                catch { dockerServiceTestDisallowed.getImageManifestInformation(imageGroup, imageName, tagName) }
             assert(exception).isNotNull {
                 assert(it.actual::class).isEqualTo(BadRequestException::class)
                 assert(it.actual.message).isEqualTo("Invalid Docker Registry URL")

--- a/src/test/kotlin/no/skatteetaten/aurora/cantus/service/DockerRegistryServiceTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/cantus/service/DockerRegistryServiceTest.kt
@@ -26,7 +26,7 @@ class DockerRegistryServiceTest {
     private val server = MockWebServer()
     private val url = server.url("/")
     private val allowedUrls = listOf("docker-registry.no", "internal-docker-registry.no")
-    private val dockerService = DockerRegistryService<Any>(WebClient.create(), url.toString(), listOf(url.toString()))
+    private val dockerService = DockerRegistryService(WebClient.create(), url.toString(), listOf(url.toString()))
 
     @BeforeEach
     fun setUp() {
@@ -91,7 +91,7 @@ class DockerRegistryServiceTest {
 
     @Test
     fun `Verify that disallowed docker registry url returns bad request error`() {
-        val dockerServiceTestDisallowed = DockerRegistryService<Any>(WebClient.create(), url.toString(), allowedUrls)
+        val dockerServiceTestDisallowed = DockerRegistryService(WebClient.create(), url.toString(), allowedUrls)
 
         server.execute {
             val exception =


### PR DESCRIPTION
Denne tar ikke høyde for felles respons format. Se branch https://github.com/Skatteetaten/cantus/tree/feature/AOS-3121-bytte-av-response-format-til-hal-hypermedia-format for å se arbeidet som pågår. 