### PR TITLE
bugfix/request param top level list change

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryController.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryController.kt
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
+data class TagUrls(val listOfTagUrls: List<String>)
+
 @RestController
 class DockerRegistryController(
     val dockerRegistryService: DockerRegistryService,
@@ -26,14 +28,14 @@ class DockerRegistryController(
 
     @PostMapping("/manifest")
     fun getManifestInformationList(
-        @RequestBody tagUrls: List<String>,
+        @RequestBody tagUrls: TagUrls,
         @RequestHeader(required = false, value = HttpHeaders.AUTHORIZATION) bearerToken: String?
     ): AuroraResponse<ImageTagResource> {
 
         val responses =
             runBlocking(MDCContext() + threadPoolContext) {
                 val deferred =
-                    tagUrls.map {
+                    tagUrls.listOfTagUrls.map {
                         async { getImageTagResource(bearerToken, it) }
                     }
                 deferred.map { it.await() }

--- a/src/main/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryController.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryController.kt
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
-data class TagUrls(val listOfTagUrls: List<String>)
+data class TagUrlsWrapper(val tagUrls: List<String>)
 
 @RestController
 class DockerRegistryController(
@@ -28,14 +28,14 @@ class DockerRegistryController(
 
     @PostMapping("/manifest")
     fun getManifestInformationList(
-        @RequestBody tagUrls: TagUrls,
+        @RequestBody tagUrlsWrapper: TagUrlsWrapper,
         @RequestHeader(required = false, value = HttpHeaders.AUTHORIZATION) bearerToken: String?
     ): AuroraResponse<ImageTagResource> {
 
         val responses =
             runBlocking(MDCContext() + threadPoolContext) {
                 val deferred =
-                    tagUrls.listOfTagUrls.map {
+                    tagUrlsWrapper.tagUrls.map {
                         async { getImageTagResource(bearerToken, it) }
                     }
                 deferred.map { it.await() }

--- a/src/test/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryControllerContractTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryControllerContractTest.kt
@@ -79,7 +79,7 @@ class DockerRegistryControllerContractTest {
     @Test
     fun `Get docker registry image manifest with POST`() {
         val manifest = ImageManifestDtoBuilder().build()
-        val tagUrl = TagUrls(
+        val tagUrl = TagUrlsWrapper(
             listOf(
                 "$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami/2",
                 "$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami/1"

--- a/src/test/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryControllerContractTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryControllerContractTest.kt
@@ -79,7 +79,7 @@ class DockerRegistryControllerContractTest {
     @Test
     fun `Get docker registry image manifest with POST`() {
         val manifest = ImageManifestDtoBuilder().build()
-        val tagUrl = TagUrlsWrapper(
+        val tagUrlsWrapper = TagUrlsWrapper(
             listOf(
                 "$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami/2",
                 "$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami/1"
@@ -95,7 +95,7 @@ class DockerRegistryControllerContractTest {
         mockMvc.post(
             path = Path("/manifest"),
             headers = HttpHeaders().contentType(),
-            body = tagUrl
+            body = tagUrlsWrapper
         ) {
             statusIsOk()
                 .responseJsonPath("$").equalsObject(imageTagResource)
@@ -108,6 +108,7 @@ class DockerRegistryControllerContractTest {
     @Test
     fun `Get docker registry image tags with GET`() {
         val path = "/tags?repoUrl=url/namespace/name"
+
         given(dockerService.getImageTags(any())).willReturn(tags)
 
         val tagResource = given(mockedImageTagResourceAssembler.tagResourceToAuroraResponse(any()))
@@ -124,6 +125,7 @@ class DockerRegistryControllerContractTest {
     @Test
     fun `Get docker registry image tags grouped with GET`() {
         val path = "/tags/semantic?repoUrl=url/namespace/name"
+
         given(dockerService.getImageTags(any())).willReturn(tags)
 
         val groupedTagResource =

--- a/src/test/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryControllerContractTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryControllerContractTest.kt
@@ -79,9 +79,11 @@ class DockerRegistryControllerContractTest {
     @Test
     fun `Get docker registry image manifest with POST`() {
         val manifest = ImageManifestDtoBuilder().build()
-        val tagUrl = listOf(
-            "$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami/2",
-            "$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami/1"
+        val tagUrl = TagUrls(
+            listOf(
+                "$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami/2",
+                "$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami/1"
+            )
         )
 
         given(dockerService.getImageManifestInformation(any())).willReturn(manifest)

--- a/src/test/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryControllerTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryControllerTest.kt
@@ -79,7 +79,7 @@ class DockerRegistryControllerTest {
 
     @Test
     fun `Get docker registry image manifest with POST given missing resources`() {
-        val tagUrl = TagUrls(listOf("$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami/2"))
+        val tagUrl = TagUrlsWrapper(listOf("$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami/2"))
 
         val notFoundStatus = HttpStatus.NOT_FOUND
 
@@ -98,7 +98,7 @@ class DockerRegistryControllerTest {
             statusIsOk()
                 .responseJsonPath("$.success").isFalse()
                 .responseJsonPath("$.items").isEmpty()
-                .responseJsonPath("$.failure[0].url").equalsValue(tagUrl.listOfTagUrls.first())
+                .responseJsonPath("$.failure[0].url").equalsValue(tagUrl.tagUrls.first())
                 .responseJsonPath("$.failure[0].errorMessage")
                 .equalsValue("Resource could not be found status=${notFoundStatus.value()} message=${notFoundStatus.reasonPhrase}")
         }
@@ -106,10 +106,10 @@ class DockerRegistryControllerTest {
 
     @Test
     fun `Post request given invalid tagUrl in body`() {
-        val tagUrl = TagUrls(listOf(""))
+        val tagUrl = TagUrlsWrapper(listOf(""))
 
         given(dockerService.getImageManifestInformation(any()))
-            .willThrow(BadRequestException("Invalid url=${tagUrl.listOfTagUrls.first()}"))
+            .willThrow(BadRequestException("Invalid url=${tagUrl.tagUrls.first()}"))
 
         mockMvc.post(
             path = Path("/manifest"),
@@ -118,9 +118,9 @@ class DockerRegistryControllerTest {
         ) {
             responseJsonPath("$.items").isEmpty()
                 .responseJsonPath("$.success").isFalse()
-                .responseJsonPath("$.failure[0].url").equalsValue(tagUrl.listOfTagUrls.first())
+                .responseJsonPath("$.failure[0].url").equalsValue(tagUrl.tagUrls.first())
                 .responseJsonPath("$.failure[0].errorMessage")
-                .equalsValue("Invalid url=${tagUrl.listOfTagUrls.first()}")
+                .equalsValue("Invalid url=${tagUrl.tagUrls.first()}")
         }
     }
 
@@ -140,7 +140,7 @@ class DockerRegistryControllerTest {
 
     @Test
     fun `Get manifest given no authorization token throw ForbiddenException`() {
-        val tagUrl = TagUrls(listOf("$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami/2"))
+        val tagUrl = TagUrlsWrapper(listOf("$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami/2"))
 
         given(dockerService.getImageManifestInformation(any()))
             .willThrow(ForbiddenException("Authorization bearer token is not present"))
@@ -177,7 +177,7 @@ class DockerRegistryControllerTest {
 
     @Test
     fun `Post request given throw IllegalStateException`() {
-        val tagUrl = TagUrls(listOf("$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami/2"))
+        val tagUrl = TagUrlsWrapper(listOf("$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami/2"))
 
         given(dockerService.getImageManifestInformation(any()))
             .willThrow(IllegalStateException("An error has occurred"))

--- a/src/test/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryControllerTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryControllerTest.kt
@@ -79,9 +79,7 @@ class DockerRegistryControllerTest {
 
     @Test
     fun `Get docker registry image manifest with POST given missing resources`() {
-        val tagUrl = listOf(
-            "$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami/2"
-        )
+        val tagUrl = TagUrls(listOf("$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami/2"))
 
         val notFoundStatus = HttpStatus.NOT_FOUND
 
@@ -100,7 +98,7 @@ class DockerRegistryControllerTest {
             statusIsOk()
                 .responseJsonPath("$.success").isFalse()
                 .responseJsonPath("$.items").isEmpty()
-                .responseJsonPath("$.failure[0].url").equalsValue(tagUrl.first())
+                .responseJsonPath("$.failure[0].url").equalsValue(tagUrl.listOfTagUrls.first())
                 .responseJsonPath("$.failure[0].errorMessage")
                 .equalsValue("Resource could not be found status=${notFoundStatus.value()} message=${notFoundStatus.reasonPhrase}")
         }
@@ -108,10 +106,10 @@ class DockerRegistryControllerTest {
 
     @Test
     fun `Post request given invalid tagUrl in body`() {
-        val tagUrl = listOf("")
+        val tagUrl = TagUrls(listOf(""))
 
         given(dockerService.getImageManifestInformation(any()))
-            .willThrow(BadRequestException("Invalid url=${tagUrl.first()}"))
+            .willThrow(BadRequestException("Invalid url=${tagUrl.listOfTagUrls.first()}"))
 
         mockMvc.post(
             path = Path("/manifest"),
@@ -120,8 +118,9 @@ class DockerRegistryControllerTest {
         ) {
             responseJsonPath("$.items").isEmpty()
                 .responseJsonPath("$.success").isFalse()
-                .responseJsonPath("$.failure[0].url").equalsValue(tagUrl.first())
-                .responseJsonPath("$.failure[0].errorMessage").equalsValue("Invalid url=${tagUrl.first()}")
+                .responseJsonPath("$.failure[0].url").equalsValue(tagUrl.listOfTagUrls.first())
+                .responseJsonPath("$.failure[0].errorMessage")
+                .equalsValue("Invalid url=${tagUrl.listOfTagUrls.first()}")
         }
     }
 
@@ -141,7 +140,7 @@ class DockerRegistryControllerTest {
 
     @Test
     fun `Get manifest given no authorization token throw ForbiddenException`() {
-        val tagUrl = listOf("$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami/2")
+        val tagUrl = TagUrls(listOf("$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami/2"))
 
         given(dockerService.getImageManifestInformation(any()))
             .willThrow(ForbiddenException("Authorization bearer token is not present"))
@@ -178,7 +177,7 @@ class DockerRegistryControllerTest {
 
     @Test
     fun `Post request given throw IllegalStateException`() {
-        val tagUrl = listOf("$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami/2")
+        val tagUrl = TagUrls(listOf("$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami/2"))
 
         given(dockerService.getImageManifestInformation(any()))
             .willThrow(IllegalStateException("An error has occurred"))

--- a/src/test/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryControllerTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/cantus/controller/DockerRegistryControllerTest.kt
@@ -79,7 +79,7 @@ class DockerRegistryControllerTest {
 
     @Test
     fun `Get docker registry image manifest with POST given missing resources`() {
-        val tagUrl = TagUrlsWrapper(listOf("$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami/2"))
+        val tagUrlsWrapper = TagUrlsWrapper(listOf("$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami/2"))
 
         val notFoundStatus = HttpStatus.NOT_FOUND
 
@@ -93,12 +93,12 @@ class DockerRegistryControllerTest {
         mockMvc.post(
             path = Path("/manifest"),
             headers = HttpHeaders().contentType(),
-            body = tagUrl
+            body = tagUrlsWrapper
         ) {
             statusIsOk()
                 .responseJsonPath("$.success").isFalse()
                 .responseJsonPath("$.items").isEmpty()
-                .responseJsonPath("$.failure[0].url").equalsValue(tagUrl.tagUrls.first())
+                .responseJsonPath("$.failure[0].url").equalsValue(tagUrlsWrapper.tagUrls.first())
                 .responseJsonPath("$.failure[0].errorMessage")
                 .equalsValue("Resource could not be found status=${notFoundStatus.value()} message=${notFoundStatus.reasonPhrase}")
         }
@@ -106,27 +106,28 @@ class DockerRegistryControllerTest {
 
     @Test
     fun `Post request given invalid tagUrl in body`() {
-        val tagUrl = TagUrlsWrapper(listOf(""))
+        val tagUrlsWrapper = TagUrlsWrapper(listOf(""))
 
         given(dockerService.getImageManifestInformation(any()))
-            .willThrow(BadRequestException("Invalid url=${tagUrl.tagUrls.first()}"))
+            .willThrow(BadRequestException("Invalid url=${tagUrlsWrapper.tagUrls.first()}"))
 
         mockMvc.post(
             path = Path("/manifest"),
-            body = tagUrl,
+            body = tagUrlsWrapper,
             headers = HttpHeaders().contentType()
         ) {
             responseJsonPath("$.items").isEmpty()
                 .responseJsonPath("$.success").isFalse()
-                .responseJsonPath("$.failure[0].url").equalsValue(tagUrl.tagUrls.first())
+                .responseJsonPath("$.failure[0].url").equalsValue(tagUrlsWrapper.tagUrls.first())
                 .responseJsonPath("$.failure[0].errorMessage")
-                .equalsValue("Invalid url=${tagUrl.tagUrls.first()}")
+                .equalsValue("Invalid url=${tagUrlsWrapper.tagUrls.first()}")
         }
     }
 
     @Test
     fun `Get tags given no authorization token throw ForbiddenException`() {
         val path = "/tags?repoUrl=$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami"
+
         given(dockerService.getImageTags(any()))
             .willThrow(ForbiddenException("Authorization bearer token is not present"))
 
@@ -140,14 +141,14 @@ class DockerRegistryControllerTest {
 
     @Test
     fun `Get manifest given no authorization token throw ForbiddenException`() {
-        val tagUrl = TagUrlsWrapper(listOf("$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami/2"))
+        val tagUrlsWrapper = TagUrlsWrapper(listOf("$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami/2"))
 
         given(dockerService.getImageManifestInformation(any()))
             .willThrow(ForbiddenException("Authorization bearer token is not present"))
 
         mockMvc.post(
             path = Path("/manifest"),
-            body = tagUrl,
+            body = tagUrlsWrapper,
             headers = HttpHeaders().contentType()
         ) {
             statusIsOk()
@@ -177,14 +178,14 @@ class DockerRegistryControllerTest {
 
     @Test
     fun `Post request given throw IllegalStateException`() {
-        val tagUrl = TagUrlsWrapper(listOf("$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami/2"))
+        val tagUrlsWrapper = TagUrlsWrapper(listOf("$defaultTestRegistry/no_skatteetaten_aurora_demo/whoami/2"))
 
         given(dockerService.getImageManifestInformation(any()))
             .willThrow(IllegalStateException("An error has occurred"))
 
         mockMvc.post(
             path = Path("/manifest"),
-            body = tagUrl,
+            body = tagUrlsWrapper,
             headers = HttpHeaders().contentType()
         ) {
             responseJsonPath("$.failure[0].errorMessage").equalsValue("An error has occurred")

--- a/src/test/kotlin/no/skatteetaten/aurora/cantus/service/DockerRegistryServiceNetworkTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/cantus/service/DockerRegistryServiceNetworkTest.kt
@@ -68,7 +68,7 @@ class DockerRegistryServiceNetworkTest {
     @ParameterizedTest
     @EnumSource(
         value = SocketPolicy::class,
-        names = ["DISCONNECT_AFTER_REQUEST", "DISCONNECT_DURING_RESPONSE_BODY", "NO_RESPONSE"],
+        names = ["DISCONNECT_AFTER_REQUEST", "DISCONNECT_DURING_RESPONSE_BODY", "NO_RESPONSE"],ls
         mode = EnumSource.Mode.INCLUDE
     )
     fun `Handle connection failure in retrieve that throws exception`(socketPolicy: SocketPolicy) {

--- a/src/test/kotlin/no/skatteetaten/aurora/cantus/service/DockerRegistryServiceNetworkTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/cantus/service/DockerRegistryServiceNetworkTest.kt
@@ -68,7 +68,7 @@ class DockerRegistryServiceNetworkTest {
     @ParameterizedTest
     @EnumSource(
         value = SocketPolicy::class,
-        names = ["DISCONNECT_AFTER_REQUEST", "DISCONNECT_DURING_RESPONSE_BODY", "NO_RESPONSE"],ls
+        names = ["DISCONNECT_AFTER_REQUEST", "DISCONNECT_DURING_RESPONSE_BODY", "NO_RESPONSE"],
         mode = EnumSource.Mode.INCLUDE
     )
     fun `Handle connection failure in retrieve that throws exception`(socketPolicy: SocketPolicy) {


### PR DESCRIPTION
Request body has been changed from a top level array to an object containing an array. This is because top level JSON arrays are a known vulnerability. 